### PR TITLE
highlight comments in deps files

### DIFF
--- a/syntax/paketdeps.vim
+++ b/syntax/paketdeps.vim
@@ -14,6 +14,8 @@ syntax match paketDepsKeyword /^\s*nuget/
 syntax match paketDepsKeyword /^\s*http/
 syntax match paketDepsKeyword /^\s*github/
 syntax match paketDepsKeyword /^\s*group/
+syntax match paketDepsComment /^#.*/
+syntax match paketDepsComment /^\/\/.*/
 
 syntax match paketDepsSymbol />=/
 syntax match paketDepsSymbol /\~>/
@@ -47,5 +49,6 @@ highlight link paketDepsVersion Float
 highlight link paketDepsOption Boolean
 highlight link paketDepsUrl Identifier
 highlight link paketDepsStr String
+highlight link paketDepsComment Comment
 
 let b:current_syntax = "paketdeps"


### PR DESCRIPTION
paket.dependencies files do not have comments highlighted, which is allowed according to the docs: https://fsprojects.github.io/Paket/dependencies-file.html#Comments. This copies the comment handling from the paketlocal syntax to the paketdeps file.